### PR TITLE
Fix YAML error when lacksK8sScript is true

### DIFF
--- a/samba4/templates/deployment.yaml
+++ b/samba4/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
-{{ if .Values.image.lacksK8sScript -}}
+{{ if .Values.image.lacksK8sScript }}
       - name: scripts
         configMap:
           name: {{ include "samba4.fullname" . }}-packagescripts


### PR DESCRIPTION
Fixes the overly-aggressive trimming of whitespace in an if statement, which produced invalid YAML under true condition:

I.e, when lacksK8sScript is true, the deployment would fail a helm lint as follows:

```
helm lint .
==> Linting .
[INFO] Chart.yaml: icon is recommended
[ERROR] templates/deployment.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 70: did not find expected key

Error: 1 chart(s) linted, 1 chart(s) failed
```
